### PR TITLE
Explained how to create an export for use by this importer.

### DIFF
--- a/wp_to_org2blog.py
+++ b/wp_to_org2blog.py
@@ -1,6 +1,20 @@
 #!/usr/bin/env python
 
-"""wp_to_org2blog.py: Convert wordpress.xml to org2blog posts."""
+"""wp_to_org2blog.py: Convert wordpress.xml to org2blog posts.
+
+To create and export of Posts and nothing else:
+
+- Log in to your WordPress site
+- Dashboard, Tools, Export
+- Posts
+  - Categories: All
+  - Authors: All
+  - Date range start, end: "Start Date", "End Date"
+    - Returns every post
+  - Status: All
+- Direct download and add.
+
+"""
 
 __author__ = "Puneeth Chaganti"
 __copyright__ = "Copyright 2011"


### PR DESCRIPTION
Create an export only including "Posts".

Reminder for anyone who is unfamiliar with the WordPress backup mechanism:

This importer only uses a "Posts" export.

It will fail on the "Everything" export.